### PR TITLE
Fix timer pipelines

### DIFF
--- a/zuul.d/timer_pipelines.yaml
+++ b/zuul.d/timer_pipelines.yaml
@@ -2,6 +2,7 @@
 - pipeline:
     name: periodic-hourly
     description: This pipeline runs hourly at the mid of an hour.
+    post-review: true
     manager: independent
     precedence: low
     trigger:
@@ -11,6 +12,7 @@
 - pipeline:
     name: periodic-daily
     description: This pipeline runs jobs daily at 3am.
+    post-review: true
     manager: independent
     precedence: low
     trigger:


### PR DESCRIPTION
Periodic pipelines should be marked as post-review so that they can run
jobs that use secrets.

Signed-off-by: Dr. Jens Harbott <harbott@osism.tech>