### PR TITLE
Add osism-publish-tox-docs-staging job

### DIFF
--- a/playbooks/publishing/pre-publish.yaml
+++ b/playbooks/publishing/pre-publish.yaml
@@ -1,0 +1,8 @@
+---
+- hosts: all
+  tasks:
+    - name: install rclone
+      become: true
+      ansible.builtin.package:
+        name: rclone
+        state: present

--- a/playbooks/publishing/publish-docs.yaml
+++ b/playbooks/publishing/publish-docs.yaml
@@ -1,0 +1,21 @@
+---
+- hosts: all
+  tasks:
+    - name: create rclone config dir
+      ansible.builtin.file:
+        path: "~/.config/rclone"
+        state: directory
+        recurse: true
+        mode: "0700"
+    - name: create rclone config file
+      ansible.builtin.copy:
+        content: "{{ rclone_conf.rclone }}"
+        dest: "~/.config/rclone/rclone.conf"
+        mode: "0600"
+      no_log: true
+    - name: run rclone
+      ansible.builtin.shell: |
+        rclone copy {{ sphinx_build_dir }}/html doc:{{ zuul.project.short_name }}/
+      args:
+        chdir: "{{ zuul.project.src_dir }}"
+      changed_when: true

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -31,3 +31,13 @@
       docs and artifacts from all nodes.
     post-run:
       - playbooks/base/post-fetch.yaml
+
+- job:
+    name: osism-publish-tox-docs-staging
+    parent: tox-docs
+    final: true
+    secrets:
+      - name: rclone_conf
+        secret: osism_staging_docs_rclone_conf
+    pre-run: playbooks/pre-publish.yaml
+    post-run: playbooks/publish-docs.yaml

--- a/zuul.d/secrets.yaml
+++ b/zuul.d/secrets.yaml
@@ -1,0 +1,15 @@
+---
+- secret:
+    name: osism_staging_docs_rclone_conf
+    data:
+      rclone: !encrypted/pkcs1-oaep
+        - cAGK7XuuvOFWClZarF/tPXX1mOz2QgSJY4UQ/WP4tKGrJ2k4jozT7zngyernqOY/e4CtZ
+          SP6aXMCBKueTFXLXh8XIjOu+W4eSpGIGB8IGlx9xvnQ/Dz4InQAUk8nPv7SrOqHZoxJza
+          eMZ3i4yoqZmUUf3OoTpmNZZHMYeMCaeBiKyu01lrxNy+ajfpI0ScJyTMDm+LTgNXF+iyW
+          ZIQoQ/hqtoyPzxYTzfEL93j8suPfiI2NZ8VdcKM1IyRWXuk+Sqze7iABvZ5xLFo4bqK6k
+          anHMnTOI3gHEUo9CajOAJrltKpN6cyz9W2yiCmvqDV/y4utp3uACKDFuMTb7sT+irAdE1
+          WN38YcIj5EPyVcF7CKrgzfw/YswD2PTKrA7HgzJ2BylwQ3gR1HSPNT6iD2RX24y02a9T/
+          MVVVA0tTppK9wg+9zTKAb9tbZKJ7ht1EMQFrNu4E8dcZ/9YqNOGqTZiGT91OwkcpO3uUV
+          EA0pT62494a5GqsMp7CMI7BHjKFYl5Oj6yzRo1rZzvVpHsTXrY7jfpJn9+4T9EOQueQOz
+          coDGUonP2Kvk3opkbFWQkFfgunFe2RiQUeQ22rdbPoZWQHpn8rIMViA8hXsscmFwm/kzt
+          Hyak3/79fZIW0m3RFouWznIiJe8P/zwCoVrg1pCIi0CfgBqraN0xesC905g0Ds=


### PR DESCRIPTION
This will allow document publishing to the staging site by all osism
projects in a unified way.

Signed-off-by: Dr. Jens Harbott <harbott@osism.tech>