### PR TITLE
publish-docs: Set default sphinx_build_dir

### DIFF
--- a/playbooks/publishing/publish-docs.yaml
+++ b/playbooks/publishing/publish-docs.yaml
@@ -1,5 +1,7 @@
 ---
 - hosts: all
+  vars:
+    sphinx_build_dir: "doc/build"
   tasks:
     - name: create rclone config dir
       ansible.builtin.file:


### PR DESCRIPTION
This way we don't need to set it explicitly in every repo.

Signed-off-by: Dr. Jens Harbott <harbott@osism.tech>