### PR TITLE
Cleanup project definitions

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -1,33 +1,5 @@
 ---
 - project:
-    name: ^osfrickler.*$
-    default-branch: main
-    check:
-      jobs: []
-    gate:
-      jobs: []
-    post:
-      jobs: []
-    tag:
-      jobs: []
-
-- project:
-    name: ^osism.*$
-    default-branch: main
-    check:
-      jobs: []
-    gate:
-      jobs: []
-    post:
-      jobs: []
-    tag:
-      jobs: []
-
-- project:
-    name: zuul/zuul-jobs
-    default-branch: master
-
-- project:
     name: osism/zuul-config
     default-branch: main
     check:


### PR DESCRIPTION
Setting the default-branch via wildcard project definitions isn't
supported by zuul. Setting empty job lists isn't helpful or needed,
either. Finally the default-branch is "master" anyway, no need to set it
for the zuul-jobs project.

Signed-off-by: Dr. Jens Harbott <harbott@osism.tech>