### PR TITLE
Update secret osism_production_docs_rclone_conf

### DIFF
--- a/playbooks/publishing/publish-docs.yaml
+++ b/playbooks/publishing/publish-docs.yaml
@@ -1,7 +1,6 @@
 ---
 - hosts: all
   vars:
-    docs_publish_prefix: ""
     sphinx_build_dir: "doc/build"
   tasks:
     - name: create rclone config dir
@@ -18,7 +17,7 @@
       no_log: true
     - name: run rclone
       ansible.builtin.shell: |
-        rclone -v copy {{ sphinx_build_dir }}/html doc:{{ docs_publish_prefix }}{{ zuul.project.short_name }}/
+        rclone -v copy {{ sphinx_build_dir }}/html doc:{{ zuul.project.short_name }}/
       args:
         chdir: "{{ zuul.project.src_dir }}"
       changed_when: true

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -45,8 +45,6 @@
     secrets:
       - name: rclone_conf
         secret: osism_production_docs_rclone_conf
-    vars:
-      docs_publish_prefix: "osism/"
     pre-run: playbooks/publishing/pre-publish.yaml
     post-run: playbooks/publishing/publish-docs.yaml
 

--- a/zuul.d/secrets.yaml
+++ b/zuul.d/secrets.yaml
@@ -3,16 +3,16 @@
     name: osism_production_docs_rclone_conf
     data:
       rclone: !encrypted/pkcs1-oaep
-        - JzN1ooRgYGSAr0RAkuS35bqtrEkRA6xNNGuK3kWPBPKx9T/OFYij9JrM7+fjfjrVjuK/p
-          HZQuI33Lt+Yut56jlZEjFiSJyu8JzKqw0mBaUsPpJgrg3NEcBdbKHl9412hcAz3qd4Ef1
-          LGqWzdAAYLmw2ogiep6KyUSoIK7tdeK8r6JF0n/K6DWRE7Noh6qnham6iOM7x5LdSW+rH
-          cg6LbpDK9VUNRM0/eOdM9jY9zgVPxovzFpknJ+UfxNkMIf7bdXPWoYNRPLTNndOSjv64L
-          fsVITHD4FU6Ws6wp3tg9Jkn7MvXAI/edYt12Ew5HIVeqgu8UD2HoJuTutJV4NAS0Ah31y
-          pO6OXIjBWrKgMQsSjpziT31yqpsXX3IpSYZJn5keoegoFuhdTjZvnejSzubcEOl4evMse
-          OHGOobWRwAtJKUobdiodM2kI6VlVZFCf15NtWD6/o/3mcPR8c/uPln0BBuF37/AC9/kzc
-          +4U/eWtoJ6Ak3ZLVEie3ceYuYeO2ONYLbKk0Et3K12vl6qzlbdoF2jtfxj88qWwqBNrqt
-          f57AllrRYhUmNN2/06DeVCafji2L22NqDMvxxrOHXpUMoQ/X2AL+5QHExnmVwjLStvOY4
-          Iap/IXZ86W+XNXVh6NJ38pKNMt+YcspFuUQ0JGTX1U4sIKERqH97bNBbaRZ5G0=
+        - eenSK0K1hbTVybPfCaXfuk6wnoPFyG1uI1dWRqrGF7vouCPfkbKcOruJSsSvoR6fBde7j
+          96H0v1uX91Q6tObX2/JAjMEQhF8ozSP2mBLV748kRBpePEcHcQgiQKtt2Fp6uxnrVVkFR
+          o3lngfnGskPHBIM4YVxdLc09Mr3q8uGrMKfTzqpMVO+WJmgrLWGlryynHKladGxvuClC8
+          iCckAa5sjSYkNQG8oey1opV+yZPw9vqPB+UeJF7E1Z1YgQuX+dWTZMIkftyKH4tvCP5wm
+          tGzfi0l9hxdC8++nEiAoLTkNP92qSH+a9QdZUW530zYoqpvhOoW67vsPDeV3p14dIz4kp
+          +caIBCqi1o7QYY3Vrwwi9f/Wi/bnLPPE8s2GfDjX4b4+sy1gm8R6Te7PcUsb4e/H3/u+5
+          cF3tpEEZICSiCXwlXTf3GuMKzRqAWwiw3TaZSWSk/qQl7eMHT5JKJ1OqLhZMfrxSKIL4Y
+          SU0LZcLFpA+GCve6rlnEW+JHnUZAq3/qouEXcLezZ8iQ+LkoGdqi6z6lwwTo1zjCGrpVb
+          YZbSRD3THYMj41bA5Z5luQy155JAm9jpgIzeITvcXXtsJMXFGOy9OmX1grDlSQe+4g87t
+          /0o2NYcnudUgBaJzYqwYkRmYFRIGoBkGvbFJCh2QkXZaXxQA5Fls6p4FB2axTA=
 
 - secret:
     name: osism_staging_docs_rclone_conf


### PR DESCRIPTION
Use an account that has the correct target direction, remove the
workaround that was trying to insert an additional path segment (which
wasn't working anyway).

Signed-off-by: Dr. Jens Harbott <harbott@osism.tech>