### PR TITLE
Re-encrypt rclone secrets

### DIFF
--- a/zuul.d/secrets.yaml
+++ b/zuul.d/secrets.yaml
@@ -3,28 +3,28 @@
     name: osism_production_docs_rclone_conf
     data:
       rclone: !encrypted/pkcs1-oaep
-        - eenSK0K1hbTVybPfCaXfuk6wnoPFyG1uI1dWRqrGF7vouCPfkbKcOruJSsSvoR6fBde7j
-          96H0v1uX91Q6tObX2/JAjMEQhF8ozSP2mBLV748kRBpePEcHcQgiQKtt2Fp6uxnrVVkFR
-          o3lngfnGskPHBIM4YVxdLc09Mr3q8uGrMKfTzqpMVO+WJmgrLWGlryynHKladGxvuClC8
-          iCckAa5sjSYkNQG8oey1opV+yZPw9vqPB+UeJF7E1Z1YgQuX+dWTZMIkftyKH4tvCP5wm
-          tGzfi0l9hxdC8++nEiAoLTkNP92qSH+a9QdZUW530zYoqpvhOoW67vsPDeV3p14dIz4kp
-          +caIBCqi1o7QYY3Vrwwi9f/Wi/bnLPPE8s2GfDjX4b4+sy1gm8R6Te7PcUsb4e/H3/u+5
-          cF3tpEEZICSiCXwlXTf3GuMKzRqAWwiw3TaZSWSk/qQl7eMHT5JKJ1OqLhZMfrxSKIL4Y
-          SU0LZcLFpA+GCve6rlnEW+JHnUZAq3/qouEXcLezZ8iQ+LkoGdqi6z6lwwTo1zjCGrpVb
-          YZbSRD3THYMj41bA5Z5luQy155JAm9jpgIzeITvcXXtsJMXFGOy9OmX1grDlSQe+4g87t
-          /0o2NYcnudUgBaJzYqwYkRmYFRIGoBkGvbFJCh2QkXZaXxQA5Fls6p4FB2axTA=
+        - ZiHoWPasXx9iUh2eZ2HxQfSd14dY8FDcZneN6HGvxCN1lG5kxpKN0VIfcTiLLOJ+ZXvum
+          JGNna5SCKqI0Zgi8QSYHK9yUU9fpAzNAeW8HZdi8ylVPffTZHLwefZCZYZwDUWZ/903xL
+          Q72IRtf01es7T/VmYqjNdbSfEbzhF8Zxg+kHHYJFvjn9IczKMQdg95JoxgNqWFRYfZlfs
+          mqG3ljQjmkNCZzNrfZxbKzTxytzZExtIIWepSQ8M5WtE7RTw0jf9QllWYvhj+ZAZxSn6A
+          3etApQC4XNFMOiQ4QYp2xDulR+nPbdrupcOKeMYGKAkii5+erhRgvNwQ+TTz6UvbWcQJF
+          xnLbvOnZFur6hwlX59JLKsNMPln+Up3BhRTwLZKgH1YBWQLfNNNJWeF+IY07XD5zqBP93
+          rqXGRYtkDIj9Ir53ZN4Jxb3iYOnEFbTIvQvQYNBMF57kQ1Nlh/g3ZzM9zcxa2kc+EVFMl
+          xWPs0EgVPWui6K4UvqwAvNntAsc9W6QdpJ6ZGDVClZzyaAIukigtlxOEZmeEchfyh25nZ
+          UEnQGyWU9bxo5l7hx/GFaolb6VVKdScsszrM1zg+O/AqEdbp9BO94IpK3eHgSzIJiU5yw
+          OP0G6i0z0dVPNYOijeMvRDwnHCnoGnskMssD160TUojDnG5PhS2SzDOXd8/dpg=
 
 - secret:
     name: osism_staging_docs_rclone_conf
     data:
       rclone: !encrypted/pkcs1-oaep
-        - cAGK7XuuvOFWClZarF/tPXX1mOz2QgSJY4UQ/WP4tKGrJ2k4jozT7zngyernqOY/e4CtZ
-          SP6aXMCBKueTFXLXh8XIjOu+W4eSpGIGB8IGlx9xvnQ/Dz4InQAUk8nPv7SrOqHZoxJza
-          eMZ3i4yoqZmUUf3OoTpmNZZHMYeMCaeBiKyu01lrxNy+ajfpI0ScJyTMDm+LTgNXF+iyW
-          ZIQoQ/hqtoyPzxYTzfEL93j8suPfiI2NZ8VdcKM1IyRWXuk+Sqze7iABvZ5xLFo4bqK6k
-          anHMnTOI3gHEUo9CajOAJrltKpN6cyz9W2yiCmvqDV/y4utp3uACKDFuMTb7sT+irAdE1
-          WN38YcIj5EPyVcF7CKrgzfw/YswD2PTKrA7HgzJ2BylwQ3gR1HSPNT6iD2RX24y02a9T/
-          MVVVA0tTppK9wg+9zTKAb9tbZKJ7ht1EMQFrNu4E8dcZ/9YqNOGqTZiGT91OwkcpO3uUV
-          EA0pT62494a5GqsMp7CMI7BHjKFYl5Oj6yzRo1rZzvVpHsTXrY7jfpJn9+4T9EOQueQOz
-          coDGUonP2Kvk3opkbFWQkFfgunFe2RiQUeQ22rdbPoZWQHpn8rIMViA8hXsscmFwm/kzt
-          Hyak3/79fZIW0m3RFouWznIiJe8P/zwCoVrg1pCIi0CfgBqraN0xesC905g0Ds=
+        - NZdHjrDm/QSiaFEo4drW+vsLr2ml3MPVqJQqChkqfDsBU/YS8Y4C8qwWJoytztTJP43Uw
+          aw3rMH3LCK55Oo1gqCqFjXOTYXaujvuLVf0vwQsUb8rDetKyNacu/+7qT+18JS+JpfnKd
+          0/GrSe4mM+AKhyLd3USK8vxiqreW3cCefSb9zgqi2dtNBK9HhvGW3o/+hBSIknxgH1cUa
+          g5RUkdc/wzEPErVcdFXHZO5CXLELlMfcKJ+D1DE5taV93FH+0adDsMvlob9diSlQlQrRN
+          yXVJNJI4HtDjvEylHGES+hWYFT4oKKYVRDbm8ntGCtn1J98a7zslFk47UiPy7XhdhDGGP
+          iIPy/AS6BmKhD4u9RFG7wDbxGQkXEICHw5plTJHIKb+Hx6XW44V8OsLYm+p3C+gK46OX7
+          JXb1+2eLlBFOCp9NDz9J9u3n+5s5N/ehb4Tgbxyse72WrjWXvt7HF/pSU7CYU5MotTNiA
+          cQ4d5ADbnw9b96IF4NA/dlMN5OInDswHCZACqYX9Yv9xI5Y6azOkyaHgpwGuI6Q/BnqRY
+          YWR+urOLjQZKfhHP2i/dMVtBRoBOCGPElQbLq3Owta/o48RbFu0hOmWFWb9AdWZrll2Ti
+          QR2zBBDc2v+G45Av1lKWd87pAYLxwLlrFGYt/Ww7c4JmDQnWu1r3dOvk9fTEVs=


### PR DESCRIPTION
After the Zuul server has been reinstalled, the key for the secrets has changed, so they needed to be encrypted again.

Signed-off-by: Dr. Jens Harbott <harbott@osism.tech>