### PR TITLE
revert 46b99b7bde3339582e17765f14587f955b5f89e8

### DIFF
--- a/playbooks/base/pre.yaml
+++ b/playbooks/base/pre.yaml
@@ -6,4 +6,3 @@
     - add-build-sshkey
     - start-zuul-console
     - prepare-workspace
-    - validate-dco-license

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -2,6 +2,7 @@
 - project:
     name: osism/zuul-config
     default-branch: main
+    merge-mode: "squash-merge"
     check:
       jobs:
         - noop


### PR DESCRIPTION
DCO check does not work properly this way. Zuul uses a merger which creates commit messages on their own without DCO. Therefore the check will always fail. The commit message from zuul looks like this in a check pipeline:

```
commit 3fe2d09633c95842358efcc05a838e55dd4b5803
Author: Zuul Merger Default <zuul.merger.default@example.com>
Date:   Fri Feb 24 05:45:36 2023 +0000

    Merge change 68,46035de4084ab6e2cf70ad67071d14e0f8ab62c0
```

Additionally added a merge-mode default value

Signed-off-by: Tim Beermann <beermann@osism.tech>
