### PR TITLE
Add nodeset ubuntu-jammy-large

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -17,10 +17,8 @@
     roles:
       - zuul: zuul/zuul-jobs
     timeout: 1800
-    nodeset:
-      nodes:
-        - name: ubuntu-jammy
-          label: ubuntu-jammy
+    nodeset: ubuntu-jammy
+
 - job:
     name: base-extra-logs
     parent: base

--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -1,0 +1,12 @@
+---
+- nodeset:
+    name: ubuntu-jammy
+    nodes:
+      - name: ubuntu-jammy
+        label: ubuntu-jammy
+
+- nodeset:
+    name: ubuntu-jammy-large
+    nodes:
+      - name: ubuntu-jammy-large
+        label: ubuntu-jammy-large


### PR DESCRIPTION
Now that we have explicit nodeset definitions, place them into their own config file and use them for the base job.