### PR TITLE
prepare-workspace: Unset delay_updates

### DIFF
--- a/roles/prepare-workspace-log/tasks/main.yaml
+++ b/roles/prepare-workspace-log/tasks/main.yaml
@@ -3,6 +3,7 @@
 
 - name: Synchronize src repos to workspace directory.
   synchronize:
+    delay_updates: false
     delete: true
     dest: "{{ zuul_workspace_root }}"
     recursive: true


### PR DESCRIPTION
This may work better for the rsync to the workspace