### PR TITLE
Add container-image-*-push jobs for python-osism

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -15,3 +15,18 @@
     tag:
       jobs:
         - noop
+
+- project:
+    name: osism/python-osism
+    post:
+      jobs:
+        - container-image-ceph-ansible-push-quincy:
+            branches: main
+        - container-image-inventory-reconciler-push:
+            branches: main
+        - container-image-kolla-ansible-push-antelope:
+            branches: main
+        - container-image-kolla-ansible-push-zed:
+            branches: main
+        - container-image-osism-ansible-push:
+            branches: main


### PR DESCRIPTION
We want new containers to be pushed when changes merge to python-osism. Since those jobs use secrets, they need to be defined in a config project.