### PR TITLE
Add a periodic-midnight pipeline

### DIFF
--- a/zuul.d/timer_pipelines.yaml
+++ b/zuul.d/timer_pipelines.yaml
@@ -18,3 +18,12 @@
     trigger:
       timer:
         - time: '0 3 * * *'
+
+- pipeline:
+    name: periodic-midnight
+    description: This pipeline runs jobs daily at 0am.
+    post-review: true
+    manager: independent
+    trigger:
+      timer:
+        - time: '0 0 * * *'


### PR DESCRIPTION
Allow some periodic jobs to run earlier than the normal daily pipeline.