### PR TITLE
Add nodesets for new distros

### DIFF
--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -1,5 +1,17 @@
 ---
 - nodeset:
+    name: centos-9-stream
+    nodes:
+      - name: centos-9-stream
+        label: centos-9-stream
+
+- nodeset:
+    name: debian-bookworm
+    nodes:
+      - name: debian-bookworm
+        label: debian-bookworm
+
+- nodeset:
     name: ubuntu-jammy
     nodes:
       - name: ubuntu-jammy


### PR DESCRIPTION
Two new labels are available now via nodepool, add matching nodesets to make it easier to use them:

- centos-9-stream
- debian-bookworm