### PR TITLE
Mark "label" pipeline with post-review

### DIFF
--- a/zuul.d/gh_pipelines.yaml
+++ b/zuul.d/gh_pipelines.yaml
@@ -118,6 +118,7 @@
 
 - pipeline:
     name: label
+    post-review: true
     description: |
       Changes that have been approved by a trusted reviewer who labeled PR with the zuul label
     manager: independent


### PR DESCRIPTION
This allows to run jobs that need secrets, like
testbed-deploy-managerless.