### PR TITLE
Add diagnose-first-sudo role for priv-esc debug

### DIFF
--- a/playbooks/base/pre.yaml
+++ b/playbooks/base/pre.yaml
@@ -8,3 +8,4 @@
     - start-zuul-console
     - validate-host
     - prepare-workspace-log
+    - diagnose-first-sudo

--- a/roles/diagnose-first-sudo/tasks/main.yaml
+++ b/roles/diagnose-first-sudo/tasks/main.yaml
@@ -1,0 +1,60 @@
+---
+# Diagnostic role for the intermittent
+# "Timeout (32s) waiting for privilege escalation prompt" failures.
+# Order matters: probe sudo with strace BEFORE warming any caches via
+# getent / systemctl, so a cold-start hang is captured in the trace.
+- name: Ensure log directory exists
+  ansible.builtin.file:
+    path: "{{ ansible_user_dir }}/zuul-output/logs"
+    state: directory
+    mode: "0755"
+
+- name: Probe first sudo invocation under strace
+  ansible.builtin.shell: |
+    set +e
+    out={{ ansible_user_dir }}/zuul-output/logs/sudo-strace.log
+    : > "$out"
+    if command -v strace >/dev/null 2>&1; then
+      cmd=(timeout 40 strace -f -tt -T -y \
+           -o "$out" \
+           sudo -n true)
+    else
+      echo "strace not installed; running bare sudo probe" > "$out"
+      cmd=(timeout 40 sudo -n true)
+    fi
+    { TIMEFORMAT='WALL: %3R s'; time "${cmd[@]}"; } 2> "$out.time"
+    echo "EXIT: $?" >> "$out.time"
+  args:
+    executable: /bin/bash
+  failed_when: false
+
+- name: Snapshot DNS / PAM / logind state (no become)
+  ansible.builtin.shell: |
+    set +e
+    out={{ ansible_user_dir }}/zuul-output/logs/sudo-debug.txt
+    {
+      echo "== date ==";            date -Iseconds
+      echo "== uptime ==";          uptime
+      echo "== boot age (s) ==";    awk '{print int($1)}' /proc/uptime
+      echo "== /etc/hostname =="; cat /etc/hostname
+      echo "== /etc/hosts ==";      cat /etc/hosts
+      echo "== nsswitch.conf ==";   cat /etc/nsswitch.conf
+      echo "== resolv.conf ==";     cat /etc/resolv.conf 2>/dev/null
+      echo "== getent ahosts =="
+      getent ahosts "$(cat /etc/hostname)"
+      echo "== timed getent hosts =="
+      { TIMEFORMAT='getent: %3R s'; time getent hosts "$(cat /etc/hostname)"; } 2>&1
+      echo "== systemd-logind active =="
+      systemctl is-active systemd-logind
+      echo "== systemd-logind ActiveEnterTimestampMonotonic =="
+      systemctl show systemd-logind -p ActiveEnterTimestampMonotonic
+      echo "== systemd-resolved active =="
+      systemctl is-active systemd-resolved 2>/dev/null
+      echo "== /etc/pam.d/sudo =="
+      cat /etc/pam.d/sudo 2>/dev/null
+      echo "== sudoers.d listing =="
+      ls -la /etc/sudoers.d/ 2>/dev/null
+    } > "$out" 2>&1
+  args:
+    executable: /bin/bash
+  failed_when: false


### PR DESCRIPTION
## Summary

- Adds a `diagnose-first-sudo` role to `playbooks/base/pre.yaml`, run after `prepare-workspace-log` and before any job-defined `become` task.
- On every job, captures two artifacts under `~/zuul-output/logs/` (auto-uploaded):
  - `sudo-strace.log` / `.time` -- a `sudo -n true` probe wrapped in `strace -f -tt -T -y` and a 40 s timeout. Runs **first**, before any DNS/PAM warming, so a cold-start hang is preserved in the trace.
  - `sudo-debug.txt` -- no-become snapshot of `/etc/hostname`, `/etc/hosts`, `nsswitch.conf`, `resolv.conf`, getent timing, `systemd-logind` state, `/etc/pam.d/sudo`, and `sudoers.d/` listing.
- Role tasks are non-fatal (`failed_when: false`), overhead ~1 s per job.

## Why

About 10 % of jobs on the `debian-bookworm` nodeset (45 / 451 in a recent local sample) fail with:

> `Timeout (32s) waiting for privilege escalation prompt: ` *(empty after the colon)*

All cached failures share the same profile: first `become:` task of the run phase (most often `ensure-pip : Update package lists`, sometimes `hadolint : Install hadolint`); 32 s of zero output from sudo; never reproduced on `ubuntu-noble*` or `orchestrator` nodes. Empty output means sudo is hanging in its own startup before `exec`'ing the payload -- not a missing-password error.

The two leading hypotheses are:
1. Local-hostname DNS resolution inside sudo (the classic `127.0.1.1 <hostname>` / `Defaults !fqdn` issue on Debian cloud images).
2. `pam_systemd` DBus call to `systemd-logind` on first session creation.

Cached job artifacts can't discriminate the two -- post.yaml currently only removes the build SSH key. This PR's instrumentation is intended to catch evidence at the moment of the next failure so we can pick the right fix instead of guessing.

## Test plan

- [ ] Merge or rebase a small bookworm-only test PR onto this branch and confirm the artifacts appear in the build log directory for a successful run.
- [ ] Wait for the next bookworm priv-esc-timeout failure (~10 % rate) and inspect `sudo-strace.log` -- a long gap after `connect(...127.0.0.53:53...)` indicates DNS; a long gap after `connect("/run/dbus/system_bus_socket"...)` indicates PAM/logind.
- [ ] Cross-check `sudo-debug.txt` from failing vs. successful builds for differences (boot age, `/etc/hosts` contents, logind activation time).

## Follow-up

Once the cause is identified, this role should be removed (or replaced by the targeted workaround it suggests, e.g. ensuring `127.0.1.1 <hostname>` is in `/etc/hosts` on the nodepool image, or removing `pam_systemd` from `/etc/pam.d/sudo`).