### PR TITLE
Collect base job output before uploading logs

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -12,6 +12,7 @@
       It also sets a default timeout value (which may be overidden).
     pre-run: playbooks/base/pre.yaml
     post-run:
+      - playbooks/base/post-fetch.yaml
       - playbooks/base/post.yaml
       - playbooks/base/post-logs.yaml
     roles:
@@ -23,9 +24,6 @@
     name: base-extra-logs
     parent: base
     description: |
-      A base job variant with extra logs.
+      Compatibility alias for the base job.
 
-      In addition to the plain base job this collects extra logs,
-      docs and artifacts from all nodes.
-    post-run:
-      - playbooks/base/post-fetch.yaml
+      Log collection from all nodes is handled by the plain base job.

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -24,6 +24,6 @@
     name: base-extra-logs
     parent: base
     description: |
-      Compatibility alias for the base job.
+      NOOP compatibility alias for the base job.
 
       Log collection from all nodes is handled by the plain base job.


### PR DESCRIPTION
## Summary

- Adds `post-fetch.yaml` to the plain `base` job's `post-run` list, before `post.yaml` and `post-logs.yaml`, so `~/zuul-output/` is fetched from job nodes while SSH is still alive.
- Removes the duplicate `post-fetch.yaml` entry from `base-extra-logs` (which now inherits the step from `base`) and updates its description to reflect that it is a compatibility alias.

## Why

The `diagnose-first-sudo` role (merged in #51) writes `sudo-strace.log`, `sudo-strace.log.time`, and `sudo-debug.txt` to `~/zuul-output/logs/` during the base pre-run. Plain `base` jobs never ran `post-fetch.yaml`, so those files were never fetched from the node and never reached the log server — making the instrumentation effectively invisible.

## Test plan

- [ ] Confirm a `debian-bookworm` build after this merge has `sudo-strace.log` and `sudo-debug.txt` present in its log manifest on `logs.services.osism.tech`.
- [ ] Confirm `base-extra-logs` jobs (if any) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)