### PR TITLE
Add ensure-output-dirs-present role to base pre-run

### DIFF
--- a/playbooks/base/pre.yaml
+++ b/playbooks/base/pre.yaml
@@ -8,4 +8,5 @@
     - start-zuul-console
     - validate-host
     - prepare-workspace-log
+    - ensure-output-dirs-present
     - diagnose-first-sudo

--- a/roles/ensure-output-dirs-present/README.rst
+++ b/roles/ensure-output-dirs-present/README.rst
@@ -1,0 +1,4 @@
+Ensure Zuul output directories are present.
+
+This role creates the standard ``logs``, ``artifacts``, and ``docs``
+directories below ``zuul_output_dir`` without removing any existing content.

--- a/roles/ensure-output-dirs-present/tasks/main.yaml
+++ b/roles/ensure-output-dirs-present/tasks/main.yaml
@@ -1,0 +1,15 @@
+---
+- name: Ensure Zuul output directories exist
+  ansible.builtin.file:
+    path: "{{ zj_zuul_output_dir }}/{{ zj_output_dir }}"
+    state: directory
+    mode: "0755"
+  loop:
+    - logs
+    - artifacts
+    - docs
+  loop_control:
+    loop_var: zj_output_dir
+  vars:
+    zj_zuul_output_dir: >-
+      {{ zuul_output_dir | default(ansible_user_dir ~ '/zuul-output') }}


### PR DESCRIPTION
## Problem

Since fd89138, `post-fetch.yaml` runs the `fetch-output` role for every
base job. That role rsyncs `logs`, `artifacts`, and `docs` from each job
node. Jobs that produce no artifacts or docs had no such directories on
the node, causing rsync to abort:

```
rsync: [sender] change_dir "/home/zuul/zuul-output/artifacts" failed: No such file or directory
```

## Fix

Add a local `ensure-output-dirs-present` role that idempotently creates
all three directories (`state: directory`) during base pre-run, after
`prepare-workspace-log` and before `diagnose-first-sudo`.

Unlike the existing `ensure-output-dirs` role in openinfra-zuul-jobs,
this role never deletes existing content, so it is safe regardless of
ordering relative to other pre-run roles that write to
`zuul-output/logs`.

## Test plan

- [ ] Trigger a plain base job (no artifact producer) and confirm no rsync error
- [ ] Confirm `diagnose-first-sudo` output still appears in uploaded logs