### PR TITLE
Add ensure-hostname-resolves-locally role to base pre-run

### DIFF
--- a/playbooks/base/pre.yaml
+++ b/playbooks/base/pre.yaml
@@ -9,4 +9,5 @@
     - validate-host
     - prepare-workspace-log
     - ensure-output-dirs-present
+    - ensure-hostname-resolves-locally
     - diagnose-first-sudo

--- a/roles/ensure-hostname-resolves-locally/tasks/main.yaml
+++ b/roles/ensure-hostname-resolves-locally/tasks/main.yaml
@@ -1,0 +1,10 @@
+---
+- name: Ensure hostname resolves locally
+  ansible.builtin.shell: |
+    set -o pipefail
+    grep -qE "^127\.0\.0\.1[[:space:]]+{{ ansible_hostname }}([[:space:]]|$)" /etc/hosts || \
+      printf '127.0.0.1 %s\n' "{{ ansible_hostname }}" | timeout 35 sudo -n tee -a /etc/hosts > /dev/null
+  args:
+    executable: /bin/bash
+  changed_when: false
+  failed_when: false


### PR DESCRIPTION
## Root cause

Build [`ad996172`](https://zuul.services.osism.tech/t/osism/build/ad9961722f714751bc7469f9ac338f8c) ([raw logs](https://logs.services.osism.tech/ad9/osism/ad9961722f714751bc7469f9ac338f8c/)) confirmed the cause of the recurring ~10% `Timeout (32s) waiting for privilege escalation prompt` failures on debian-bookworm lint jobs via `sudo-debug.txt`:

- `/etc/hostname` = `debian`
- `/etc/hosts` contains only `127.0.0.1 localhost` — `debian` is absent
- `nsswitch.conf hosts:` = `files dns` — lookup falls through to external DNS
- `systemd-resolved`: inactive — no local caching resolver
- `getent ahosts debian`: **80.083 s** — external nameservers (81.163.194.9/10)
  return NXDOMAIN after a full timeout

sudo calls `getaddrinfo()` with the current hostname during session setup. The
missing `/etc/hosts` entry causes an ~80 s DNS stall, which exceeds sudo's 32 s
privilege escalation timeout.

## Fix

Add a new `ensure-hostname-resolves-locally` role inserted immediately before
`diagnose-first-sudo` in `playbooks/base/pre.yaml`. The role appends
`127.0.0.1 <hostname>` to `/etc/hosts` if no matching entry is present,
using `sudo -n tee` — the same invocation pattern the strace probe confirms
is fast at pre-run time (DNS negative cache from node boot is still warm).

A `timeout 35` guard bounds the failure path: `sudo -n` does not trigger
Ansible's `become_timeout`, so without it the task would hang for the full
~80 s DNS timeout. `failed_when: false` keeps pre-run going so
`diagnose-first-sudo` still captures artifacts on failure.

## Cleanup

Once this fix is merged and confirmed working, the following debug scaffolding
commits can be reverted:

- `6998749` — Add diagnose-first-sudo role for priv-esc debug
- `fd89138` — Collect base job output before uploading logs
- `cec79ca` — zuul.d: clarify base-extra-logs as NOOP alias (consequence of fd89138)
- `7fe648e` — Add ensure-output-dirs-present role to base pre-run