### PR TITLE
diagnose-first-sudo: add IP-level ping probes

### DIFF
--- a/roles/diagnose-first-sudo/tasks/main.yaml
+++ b/roles/diagnose-first-sudo/tasks/main.yaml
@@ -40,6 +40,12 @@
       echo "== /etc/hosts ==";      cat /etc/hosts
       echo "== nsswitch.conf ==";   cat /etc/nsswitch.conf
       echo "== resolv.conf ==";     cat /etc/resolv.conf 2>/dev/null
+      echo "== ping 8.8.8.8 =="
+      ping -c1 -W2 8.8.8.8 2>&1 || true
+      echo "== ping 81.163.194.9 =="
+      ping -c1 -W2 81.163.194.9 2>&1 || true
+      echo "== ping 81.163.194.10 =="
+      ping -c1 -W2 81.163.194.10 2>&1 || true
       echo "== getent ahosts =="
       getent ahosts "$(cat /etc/hostname)"
       echo "== timed getent hosts =="


### PR DESCRIPTION
## Summary

- Adds `ping -c1 -W2 8.8.8.8` to distinguish public internet reachability from DNS failure
- Adds `ping -c1 -W2 81.163.194.9` and `ping -c1 -W2 81.163.194.10` to probe the Regiocloud nameservers directly by IP

## Context

The existing `sudo-debug.txt` snapshot captures `/etc/resolv.conf` and a timed `getent` lookup, which tells us when a DNS query stalls (~80s timeout on affected builds). What it cannot tell us is *why*: whether the nameservers at `81.163.194.9/10` are unreachable at the IP level, or whether the internet path itself is down.

This distinction matters because the sudo privilege-escalation timeout co-occurs with broader CI network failures (ENETUNREACH to `galaxy.ansible.com`, DNS failures to `tarballs.opendev.org`). IP-level pings inserted right after the `resolv.conf` dump will confirm scenario (a) — nameservers unreachable while internet is up — vs scenario (b) — general outage affecting all external IPs.

## Test plan

- Wait for the next build hitting `privilege-escalation-timeout` and check `sudo-debug.txt` for the new `== ping 8.8.8.8 ==` / `== ping 81.163.194.9 ==` / `== ping 81.163.194.10 ==` sections