### PR TITLE
base: Update apt cache

### DIFF
--- a/playbooks/base/pre.yaml
+++ b/playbooks/base/pre.yaml
@@ -10,3 +10,7 @@
     - prepare-workspace-log
     - ensure-output-dirs-present
     - diagnose-first-sudo
+  tasks:
+    - name: Run the equivalent of "apt-get update" as a separate step
+      ansible.builtin.apt:
+        update_cache: yes


### PR DESCRIPTION
When using a cloud image instead of nodepool-built ones, the apt cache is empty on startup, causing various ensure-* roles to fail. Temporarily add this as a workaround until we have zuul-launcher built images available.