### PR TITLE
diagnose-network: fix teardown hang, harden egress probes

### DIFF
--- a/roles/diagnose-network/tasks/main.yaml
+++ b/roles/diagnose-network/tasks/main.yaml
@@ -79,22 +79,29 @@
         # pre/post bracket. Bounded and in-line -- not a background sampler.
         for fam in 6 4; do
           echo "-- curl -$fam (3 attempts) --"
+          ok=0
           for n in 1 2 3; do
             curl -$fam -sS -m 10 -o /dev/null \
               -w "  #$n http=%{http_code} ip=%{remote_ip} t=%{time_total}s\n" \
-              "https://$d/" 2>&1 || echo "  #$n curl -$fam FAILED"
+              "https://$d/" 2>&1 && ok=1 || echo "  #$n curl -$fam FAILED"
           done
+          # Trace only the family that failed, to its resolved address:
+          # localises WHERE the failing path dies instead of tracing the
+          # healthy family. v4 via traceroute, v6 via traceroute6.
+          if [ "$ok" = 0 ]; then
+            addr=$v6; [ "$fam" = 4 ] && addr=$v4
+            tr=traceroute6; [ "$fam" = 4 ] && tr=traceroute
+            if [ -n "$addr" ] && command -v "$tr" >/dev/null 2>&1; then
+              echo "  !! curl -$fam failed 3x; $tr to $addr"
+              timeout 30 "$tr" -q1 -w2 "$addr" 2>&1
+            fi
+          fi
         done
       done
       echo "== ping -6 gateway =="
       if [ -n "$gw" ]; then
         ping -6 -c1 -W2 "${gw}%${iface}" 2>&1
       else echo "no v6 gw"; fi
-      echo "== traceroute6 to first target =="
-      set -- $targets
-      if command -v traceroute6 >/dev/null 2>&1; then
-        timeout 30 traceroute6 -q1 -w2 "$1" 2>&1
-      else echo "traceroute6 not installed"; fi
     } > "$out" 2>&1
   args:
     executable: /bin/bash

--- a/roles/diagnose-network/tasks/main.yaml
+++ b/roles/diagnose-network/tasks/main.yaml
@@ -109,21 +109,21 @@
         echo "docker not available; skipped"
       else
         echo "-- docker info (IPv6 lines) --"
-        if info=$(docker info 2>&1); then
+        if info=$(timeout 30 docker info 2>&1); then
           printf '%s\n' "$info" | grep -iE 'ipv6|ip6tables' \
             || echo "(no IPv6 lines)"
         else
-          echo "docker info FAILED (daemon down or no permission):"
+          echo "docker info FAILED/timed out (daemon down or no permission):"
           printf '%s\n' "$info" | head -5
         fi
         echo "-- /etc/docker/daemon.json --"
         cat /etc/docker/daemon.json 2>/dev/null || echo "(absent)"
         echo "-- docker network inspect bridge (EnableIPv6 + IPAM) --"
-        docker network inspect bridge 2>&1 \
+        timeout 30 docker network inspect bridge 2>&1 \
           | grep -iE '"Name"|EnableIPv6|Subnet|Gateway' \
           || echo "(inspect failed)"
         echo "-- docker buildx ls --"
-        docker buildx ls 2>&1 || echo "(buildx unavailable)"
+        timeout 30 docker buildx ls 2>&1 || echo "(buildx unavailable)"
       fi
     } >> "$out" 2>&1
   args:
@@ -153,14 +153,21 @@
         # skipping dangling (<none>) tags; fall back to any local image
         # ID (a valid run reference). Never pull. (docker image ls
         # columns: REPOSITORY TAG IMAGE_ID ...)
-        img=$(docker image ls 2>/dev/null | awk \
+        img=$(timeout 30 docker image ls 2>/dev/null | awk \
           '$1~/^(ubuntu|debian)$/ && $2!="<none>"{print $1":"$2; exit}')
-        [ -z "$img" ] && img=$(docker image ls -q 2>/dev/null | head -1)
+        if [ -z "$img" ]; then
+          img=$(timeout 30 docker image ls -q 2>/dev/null | head -1)
+        fi
         if [ -z "$img" ]; then
           echo "no local image; skipped (will not pull over a broken network)"
         else
           echo "using local image $img"
-          docker run --rm "$img" sh -c '
+          # Bound the whole probe: on the degraded node this role exists
+          # to diagnose, a wedged daemon can make `docker run` hang
+          # indefinitely and stall teardown. timeout keeps it best-effort.
+          # A killed client may orphan the container, but the node is torn
+          # down right after, so that is acceptable here.
+          timeout 60 docker run --rm "$img" sh -c '
             echo "tools: ip=$(command -v ip || echo no)" \
                  "curl=$(command -v curl || echo no)" \
                  "getent=$(command -v getent || echo no)"

--- a/roles/diagnose-network/tasks/main.yaml
+++ b/roles/diagnose-network/tasks/main.yaml
@@ -43,9 +43,12 @@
       echo "== ip -6 route show default (expires/proto ra = RA evidence) =="
       ip -6 route show default
       echo "== ip -4 route show default =="; ip -4 route show default
-      echo "== sysctl accept_ra / forwarding =="
+      echo "== accept_ra / forwarding (procfs; RA-suppression evidence) =="
       for k in all default "$iface"; do
-        sysctl "net.ipv6.conf.$k.forwarding" "net.ipv6.conf.$k.accept_ra" 2>&1
+        for s in forwarding accept_ra; do
+          v=$(cat "/proc/sys/net/ipv6/conf/$k/$s" 2>/dev/null)
+          echo "net.ipv6.conf.$k.$s = ${v:-<unavailable>}"
+        done
       done
       echo "== resolvectl status =="
       if command -v resolvectl >/dev/null 2>&1; then resolvectl status 2>&1

--- a/roles/diagnose-network/tasks/main.yaml
+++ b/roles/diagnose-network/tasks/main.yaml
@@ -57,8 +57,9 @@
         if command -v resolvectl >/dev/null 2>&1; then
           echo "-- resolvectl query --"; resolvectl query --cache=no "$d" 2>&1
         fi
-        v6=$(getent ahosts "$d" 2>/dev/null | awk '/:/{print $1; exit}')
-        v4=$(getent ahosts "$d" 2>/dev/null | awk '/\./{print $1; exit}')
+        v6=$(getent ahosts "$d" 2>/dev/null | awk '$1~/:/{print $1; exit}')
+        v4=$(getent ahosts "$d" 2>/dev/null \
+             | awk '$1~/^[0-9]+(\.[0-9]+){3}$/{print $1; exit}')
         if [ -n "$v6" ]; then
           echo "-- ip -6 route get $v6 --"; ip -6 route get "$v6" 2>&1
         fi

--- a/roles/diagnose-network/tasks/main.yaml
+++ b/roles/diagnose-network/tasks/main.yaml
@@ -105,6 +105,14 @@
     } > "$out" 2>&1
   args:
     executable: /bin/bash
+  # Hang backstop: cap the whole task so a wedged DNS/daemon call can
+  # never stall teardown before fetch-output. Sized above this task's
+  # bounded worst case (curl/traceroute timeouts) so it fires only on a
+  # genuine hang. The three post-phase tasks (300+120+180) sum to 600s,
+  # a third of the 1800s base job timeout, leaving room for fetch-output;
+  # failed_when:false swallows the async-timeout result.
+  async: 300
+  poll: 5
   changed_when: false
   failed_when: false
 
@@ -147,6 +155,8 @@
     } >> "$out" 2>&1
   args:
     executable: /bin/bash
+  async: 120  # hang backstop; see "Snapshot dual-stack network state"
+  poll: 5
   when:
     - diagnose_network_container_probe | bool
     - diagnose_network_phase == "post"
@@ -210,6 +220,8 @@
     } >> "$out" 2>&1
   args:
     executable: /bin/bash
+  async: 180  # hang backstop; see "Snapshot dual-stack network state"
+  poll: 5
   when:
     - diagnose_network_container_probe | bool
     - diagnose_network_phase == "post"

--- a/roles/diagnose-network/tasks/main.yaml
+++ b/roles/diagnose-network/tasks/main.yaml
@@ -53,6 +53,11 @@
       echo "== resolvectl status =="
       if command -v resolvectl >/dev/null 2>&1; then resolvectl status 2>&1
       else echo "resolvectl not installed"; fi
+      echo "== /etc/resolv.conf (resolver stub) =="
+      cat /etc/resolv.conf 2>/dev/null || echo "(absent)"
+      echo "== /run/systemd/resolve/resolv.conf (upstreams) =="
+      cat /run/systemd/resolve/resolv.conf 2>/dev/null \
+        || echo "(no systemd-resolved upstream file)"
       for d in $targets; do
         echo "== target: $d =="
         echo "-- getent ahosts (families glibc returns) --"

--- a/roles/diagnose-network/tasks/main.yaml
+++ b/roles/diagnose-network/tasks/main.yaml
@@ -17,7 +17,7 @@
 # ~/issues/regiocloud/ipv6-egress-instability.md for the analysis.
 #
 # Everything is best-effort and must never fail or perturb a job:
-# set +e, guard every command, failed_when/changed_when false.
+# set +e / pipefail, guard every command, failed_when/changed_when false.
 - name: Ensure log directory exists
   ansible.builtin.file:
     path: "{{ ansible_user_dir }}/zuul-output/logs"
@@ -27,6 +27,7 @@
 - name: Snapshot dual-stack network state ({{ diagnose_network_phase }})
   ansible.builtin.shell: |
     set +e
+    set -o pipefail
     phase={{ diagnose_network_phase }}
     out={{ ansible_user_dir }}/zuul-output/logs/net-debug.$phase.txt
     targets="{{ diagnose_network_targets | join(' ') }}"
@@ -128,6 +129,7 @@
 - name: Snapshot Docker/BuildKit IPv6 config (teardown)
   ansible.builtin.shell: |
     set +e
+    set -o pipefail
     phase={{ diagnose_network_phase }}
     out={{ ansible_user_dir }}/zuul-output/logs/net-debug.$phase.txt
     {
@@ -170,6 +172,7 @@
 - name: Probe container network namespace (teardown)
   ansible.builtin.shell: |
     set +e
+    set -o pipefail
     phase={{ diagnose_network_phase }}
     out={{ ansible_user_dir }}/zuul-output/logs/net-debug.$phase.txt
     targets="{{ diagnose_network_targets | join(' ') }}"

--- a/roles/diagnose-network/tasks/main.yaml
+++ b/roles/diagnose-network/tasks/main.yaml
@@ -74,14 +74,17 @@
         if [ -n "$v4" ]; then
           echo "-- ip -4 route get $v4 --"; ip -4 route get "$v4" 2>&1
         fi
-        echo "-- curl -6 --"
-        curl -6 -sS -m 10 -o /dev/null \
-          -w 'http=%{http_code} ip=%{remote_ip} t=%{time_total}s\n' \
-          "https://$d/" 2>&1 || echo "curl -6 FAILED"
-        echo "-- curl -4 --"
-        curl -4 -sS -m 10 -o /dev/null \
-          -w 'http=%{http_code} ip=%{remote_ip} t=%{time_total}s\n' \
-          "https://$d/" 2>&1 || echo "curl -4 FAILED"
+        # Several attempts per family: a single sample misclassifies a
+        # ~50%-loss path as healthy or dead by coin flip, defeating the
+        # pre/post bracket. Bounded and in-line -- not a background sampler.
+        for fam in 6 4; do
+          echo "-- curl -$fam (3 attempts) --"
+          for n in 1 2 3; do
+            curl -$fam -sS -m 10 -o /dev/null \
+              -w "  #$n http=%{http_code} ip=%{remote_ip} t=%{time_total}s\n" \
+              "https://$d/" 2>&1 || echo "  #$n curl -$fam FAILED"
+          done
+        done
       done
       echo "== ping -6 gateway =="
       if [ -n "$gw" ]; then


### PR DESCRIPTION
The `diagnose-network` role runs in the base pre/post of every job, so
since it merged it has produced thousands of `net-debug.{pre,post}.txt`
captures. This PR acts on what they show — and fixes a way the role
could break a job.

## What the current instrumentation told us

A survey of **~2400 builds over six days (2026-06-09 → 06-15)**,
classifying the host `curl` probe to `tarballs.opendev.org` at teardown:

- **IPv4 fails ~55%** of the time, every day (52–57%) — almost all
  connection timeouts. This confirms the issue's "~50% IPv4 loss" as a
  persistent fleet-wide phenomenon, not a one-off.
- **IPv6 fails ~11%**, every day (8–18%) — fast connect failures
  (ENETUNREACH-like), timeouts, and DNS-resolution failures. IPv6 egress
  is **not** reliably healthy; all three documented failure modes show
  up at the host level.
- ~42% of builds are fully healthy; failures cluster by timestamp (many
  simultaneous jobs failing together), i.e. real intermittent windows.
- Docker's bridge reports `EnableIPv6: false` → containers/BuildKit are
  IPv4-only and forced onto the more-often-failing IPv4 path.

But the captures also showed the instrumentation degrading or losing
data:

- **It hung a job.** A build wedged in post-run for 7+ hours with no logs
  uploaded — the teardown `docker run` exec probe never returned and
  stalled everything before `fetch-output`. This prompted the PR.
- `sysctl: command not found` (×3) — the `accept_ra`/`forwarding` capture
  (RA-suppression test) was silently empty on the Docker nodes.
- `ip -4 route get` was fed an IPv6 address (awk matched the dotted
  hostname) — the IPv4 route was never captured.
- No host resolver config when `resolvectl` is absent; the pre-run
  sibling role cannot cover a resolver state that changes mid-job.
- A single `curl` per family is a coin flip against a ~50%-loss path.
- It always ran `traceroute6` (the usually-healthy path) and never traced
  the family that actually failed.

## Why this PR

1. **Fix the hang so teardown can never stall a job again** — per-command
   timeouts on the daemon calls, plus an `async`/`poll` backstop on each
   teardown task. The caps (300/120/180s) sum to 600s, a third of the
   1800s base job timeout, leaving room for `fetch-output` and firing
   only on a genuine hang.
2. **Collect better, more reliable data** — close the silent-failure gaps
   above so the next failing window is fully captured.

## Changes (one logical change per commit)

- `add timeouts to teardown probes` — bound the daemon-touching `docker`
  calls; the outer `timeout 60 docker run` bounds the exec probe.
- `fix IPv4 address extraction` — anchor per family so `ip -4 route get`
  targets the v4 address.
- `read v6 sysctls from /proc` — replace the missing `sysctl` binary;
  restores the RA-suppression test.
- `capture host resolver config` — `/etc/resolv.conf` + systemd upstreams
  at teardown.
- `sample each family 3 times` — make each pre/post bracket a reliable
  verdict, not a coin toss.
- `trace the failing family` — traceroute the family whose curl failed
  (either family, or DNS, can fail), to its resolved address.
- `add async hang backstop` — per-task ceiling, robust to any future
  unbounded command.
- `set pipefail in shell probes` — satisfy the now-voting ansible-lint
  job on the role's pre-existing pipes.

## Notes for reviewers

- The role originally merged while zuul-config check/gate still ran
  `noop`; `ansible-lint` only became voting afterward (#63), so its
  `risky-shell-pipe` findings on the role's pre-existing pipes first
  surfaced on this PR — fixed via `set -o pipefail` (final commit), so
  `osism/check` passes.
- `yamllint` clean; `ansible-lint` clean (meets the `production` profile).

## Related

- osism/zuul-config#62
- osism/zuul-config#63
