### PR TITLE
Add post-timeout to base job

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -19,6 +19,7 @@
       - zuul: osism/openinfra-zuul-jobs
       - zuul: osism/zuul-jobs
     timeout: 1800
+    post-timeout: 1800
     nodeset: debian-bookworm
 
 - job:


### PR DESCRIPTION
The default is no timeout in the post phase, make sure to always end post processing in a finite time.